### PR TITLE
axnet:vsock: when connect closed, it still can be read

### DIFF
--- a/modules/axnet/src/vsock/stream.rs
+++ b/modules/axnet/src/vsock/stream.rs
@@ -222,12 +222,13 @@ impl VsockTransportOps for VsockStreamTransport {
         self.general.recv_poller(self).poll(|| {
             let mut conn_guard = conn.lock();
 
-            if conn_guard.state() != ConnectionState::Connected {
-                return Err(AxError::NotConnected);
-            }
-
             if conn_guard.rx_closed() && conn_guard.rx_buffer_used() == 0 {
                 return Ok(0); // EOF
+            }
+
+            // should allow read when connection is closed, to read remaining data
+            if conn_guard.state() != ConnectionState::Connected && conn_guard.state() != ConnectionState::Closed {
+                return Err(AxError::NotConnected);
             }
 
             if conn_guard.rx_buffer_used() == 0 {
@@ -328,7 +329,7 @@ impl Pollable for VsockStreamTransport {
                     );
                 }
             }
-            ConnectionState::Connected => {
+            ConnectionState::Connected | ConnectionState::Closed => {
                 events.set(IoEvents::IN, conn.rx_buffer_used() > 0 || conn.rx_closed());
                 events.set(IoEvents::OUT, !conn.tx_closed());
             }


### PR DESCRIPTION
axnet:vsock: when connect closed, it still can be read