### PR TITLE
fix: update doc cfg and clippy warnings

### DIFF
--- a/modules/axdriver/src/lib.rs
+++ b/modules/axdriver/src/lib.rs
@@ -57,7 +57,7 @@
 //! [dyn]: https://doc.rust-lang.org/std/keyword.dyn.html
 
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![feature(doc_cfg)]
 #![feature(associated_type_defaults)]
 #![feature(c_variadic)]
 

--- a/modules/axfs-ng/src/fs/ext4/fs.rs
+++ b/modules/axfs-ng/src/fs/ext4/fs.rs
@@ -36,7 +36,7 @@ impl Ext4Filesystem {
         Ok(Filesystem::new(fs))
     }
 
-    pub(crate) fn lock(&self) -> MutexGuard<LwExt4Filesystem> {
+    pub(crate) fn lock(&self) -> MutexGuard<'_, LwExt4Filesystem> {
         self.inner.lock()
     }
 }

--- a/modules/axfs-ng/src/fs/fat/fs.rs
+++ b/modules/axfs-ng/src/fs/fat/fs.rs
@@ -63,7 +63,7 @@ impl FatFilesystem {
 }
 
 impl FatFilesystem {
-    pub(crate) fn lock(&self) -> MutexGuard<FatFilesystemInner> {
+    pub(crate) fn lock(&self) -> MutexGuard<'_, FatFilesystemInner> {
         self.inner.lock()
     }
 }

--- a/modules/axfs-ng/src/fs/fat/util.rs
+++ b/modules/axfs-ng/src/fs/fat/util.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Datelike, NaiveDate, TimeZone, Timelike, Utc};
 
 use super::{ff, fs::FatFilesystemInner};
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct CaseInsensitiveString(pub String);
 

--- a/modules/axhal/src/lib.rs
+++ b/modules/axhal/src/lib.rs
@@ -35,7 +35,7 @@
 //! [cargo test]: https://doc.rust-lang.org/cargo/guide/tests.html
 
 #![no_std]
-#![feature(doc_auto_cfg)]
+#![cfg_attr(all(doc, not(doctest)), feature(doc_cfg))]
 
 #[allow(unused_imports)]
 #[macro_use]

--- a/modules/axnet/src/device/ethernet.rs
+++ b/modules/axnet/src/device/ethernet.rs
@@ -27,6 +27,7 @@ struct Neighbor {
 }
 
 pub struct EthernetDevice {
+    #[allow(dead_code)]
     name: String,
     inner: AxNetDevice,
     neighbors: HashMap<IpAddress, Option<Neighbor>>,

--- a/modules/axnet/src/lib.rs
+++ b/modules/axnet/src/lib.rs
@@ -13,7 +13,6 @@
 //! [smoltcp]: https://github.com/smoltcp-rs/smoltcp
 
 #![no_std]
-#![feature(ip_from)]
 #![feature(maybe_uninit_slice)]
 
 #[macro_use]

--- a/modules/axnet/src/state.rs
+++ b/modules/axnet/src/state.rs
@@ -46,7 +46,7 @@ impl StateLock {
         self.0.store(state as u8, Ordering::Release);
     }
 
-    pub fn lock(&self, expect: State) -> Result<StateGuard, State> {
+    pub fn lock(&self, expect: State) -> Result<StateGuard<'_>, State> {
         match self.0.compare_exchange(
             expect as u8,
             State::Busy as u8,

--- a/modules/axruntime/src/lib.rs
+++ b/modules/axruntime/src/lib.rs
@@ -24,7 +24,7 @@
 //! All the features are optional and disabled by default.
 
 #![cfg_attr(not(test), no_std)]
-#![feature(doc_auto_cfg)]
+#![feature(doc_cfg)]
 
 #[macro_use]
 extern crate axlog;

--- a/modules/axtask/src/lib.rs
+++ b/modules/axtask/src/lib.rs
@@ -26,7 +26,6 @@
 
 #![cfg_attr(not(test), no_std)]
 #![feature(doc_cfg)]
-#![feature(doc_auto_cfg)]
 #![feature(linkage)]
 
 #[cfg(test)]


### PR DESCRIPTION
- Replace deprecated `#![feature(doc_auto_cfg)]` with `doc_cfg` (or conditional `cfg_attr`) across the modules to avoid nightly clippy failures on Rust 1.92+.
- Fix several lifetime annotations and guard return types (`MutexGuard<'_>`, `StateGuard<'_>`) so they compile cleanly with the current compiler.
- Add `#[allow(dead_code)]` where fields are intentionally unused and drop the obsolete `#![feature(ip_from)]`.