### PR TITLE
fix: modify the receiving logic of vsock

### DIFF
--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -165,9 +165,8 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
 
     match event {
         VsockDriverEvent::ConnectionRequest(conn_id) => {
-            match manager.on_connection_request(conn_id) {
-                Ok(_) => debug!("Connection request accepted: {:?}", conn_id),
-                Err(e) => warn!("Connection request failed: {:?}, error={:?}", conn_id, e),
+            if let Err(e) = manager.on_connection_request(conn_id) {
+                warn!("Connection request failed: {:?}, error={:?}", conn_id, e);
             }
         }
 
@@ -180,7 +179,6 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
             };
 
             if free_space == 0 {
-                debug!("No free space in rx buffer for conn_id={:?}, deferring receive", conn_id);
                 PENDING_EVENTS.lock().push_back(VsockDriverEvent::Received(conn_id, len));
                 return;
             }
@@ -189,11 +187,8 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
             let max_read = core::cmp::min(free_space, buf.len());
             match dev.recv(conn_id, &mut buf[..max_read]) {
                 Ok(read_len) => {
-                    match manager.on_data_received(conn_id, &buf[..read_len]) {
-                        Ok(_) => debug!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len),
-                        Err(e) => {
-                            warn!("Failed to handle received data: conn_id={:?}, error={:?}", conn_id, e);
-                        }
+                    if let Err(e) = manager.on_data_received(conn_id, &buf[..read_len]) {
+                       warn!("Failed to handle received data: conn_id={:?}, error={:?}", conn_id, e);
                     }
                 }
                 Err(e) => {
@@ -203,16 +198,14 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
         }
 
         VsockDriverEvent::Disconnected(conn_id) => {
-            match manager.on_disconnected(conn_id) {
-                Ok(_) => debug!("Connection disconnected: {:?}", conn_id),
-                Err(e) => warn!("Failed to handle disconnection: {:?}, error={:?}", conn_id, e),
+            if let Err(e) = manager.on_disconnected(conn_id) {
+                warn!("Failed to handle disconnection: {:?}, error={:?}", conn_id, e);
             }
         }
 
         VsockDriverEvent::Connected(conn_id) => {
-            match manager.on_connected(conn_id) {
-                Ok(_) => debug!("Connection established: {:?}", conn_id),
-                Err(e) => warn!("Failed to handle connection established: {:?}, error={:?}", conn_id, e),
+            if let Err(e) = manager.on_connected(conn_id) {
+                warn!("Failed to handle connection established: {:?}, error={:?}", conn_id, e);
             }
         }
 

--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -134,11 +134,35 @@ fn poll_vsock_interfaces() -> AxResult<bool> {
     let mut buf = alloc::vec![0; 0x1000]; // 4KiB buffer for receiving data
 
     loop {
-        match dev.poll_event(&mut buf) {
+        match dev.poll_event() {
             Ok(None) => break, // no more events
             Ok(Some(event)) => {
-                event_count += 1;
-                handle_vsock_event(event, &buf);
+
+                if let VsockDriverEvent::Received(conn_id, _len) = event {
+                    let mut manager = VSOCK_CONN_MANAGER.lock();
+                    let free_space = if let Some(conn) = manager.get_connection(conn_id) {
+                        conn.lock().rx_buffer_free()
+                    } else {
+                        buf.len()
+                    };
+                    drop(manager);
+
+                    if free_space > 0 {
+                        // Read as much as the upper layer can accept, up to buf.len()
+                        let max_read = core::cmp::min(free_space, buf.len());
+                        if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
+                            let mut manager = VSOCK_CONN_MANAGER.lock();
+                            let _ = manager.on_data_received(conn_id, &buf[..read_len]);
+                            trace!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len);
+                        }
+                    }else{
+                        trace!("Vsock received event but no free space: conn_id={:?}, free_space={}", conn_id, free_space);
+                    }
+                } else {
+                    event_count += 1;
+                    handle_vsock_event(event);
+                }
+
             }
             Err(e) => {
                 info!("Failed to poll vsock event: {:?}", e);
@@ -149,7 +173,7 @@ fn poll_vsock_interfaces() -> AxResult<bool> {
     Ok(event_count > 0)
 }
 
-fn handle_vsock_event(event: VsockDriverEvent, buf: &[u8]) {
+fn handle_vsock_event(event: VsockDriverEvent) {
     let mut manager = VSOCK_CONN_MANAGER.lock();
     debug!("Handling vsock event: {:?}", event);
 
@@ -158,8 +182,8 @@ fn handle_vsock_event(event: VsockDriverEvent, buf: &[u8]) {
             let _ = manager.on_connection_request(conn_id);
         }
 
-        VsockDriverEvent::Received(conn_id, len) => {
-            let _ = manager.on_data_received(conn_id, &buf[..len]);
+        VsockDriverEvent::Received(_conn_id, _len) => {
+            // Handled in poll_vsock_interfaces directly to support backpressure
         }
 
         VsockDriverEvent::Disconnected(conn_id) => {

--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -9,9 +9,11 @@ use axsync::Mutex;
 use axtask::future::{block_on, interruptible};
 
 use crate::{alloc::string::ToString, vsock::connection_manager::VSOCK_CONN_MANAGER};
+use alloc::collections::VecDeque;
 
 // we need a global and static only one vsock device
 static VSOCK_DEVICE: Mutex<Option<AxVsockDevice>> = Mutex::new(None);
+static PENDING_EVENTS: Mutex<VecDeque<VsockDriverEvent>> = Mutex::new(VecDeque::new());
 
 /// Registers a vsock device. Only one vsock device can be registered.
 pub fn register_vsock_device(dev: AxVsockDevice) -> AxResult {
@@ -131,38 +133,20 @@ fn poll_vsock_interfaces() -> AxResult<bool> {
     let mut guard = VSOCK_DEVICE.lock();
     let dev = guard.as_mut().ok_or(AxError::NotFound)?;
     let mut event_count = 0;
-    let mut buf = alloc::vec![0; 0x1000]; // 4KiB buffer for receiving data
+
+    // Process pending events first
+    // Use core::mem::take to atomically move all events out and empty the global queue
+    let pending_events = core::mem::take(&mut *PENDING_EVENTS.lock());
+    for event in pending_events {
+        handle_vsock_event(event, dev);
+    }
 
     loop {
         match dev.poll_event() {
             Ok(None) => break, // no more events
             Ok(Some(event)) => {
-
-                if let VsockDriverEvent::Received(conn_id, _len) = event {
-                    let mut manager = VSOCK_CONN_MANAGER.lock();
-                    let free_space = if let Some(conn) = manager.get_connection(conn_id) {
-                        conn.lock().rx_buffer_free()
-                    } else {
-                        buf.len()
-                    };
-                    drop(manager);
-
-                    if free_space > 0 {
-                        // Read as much as the upper layer can accept, up to buf.len()
-                        let max_read = core::cmp::min(free_space, buf.len());
-                        if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
-                            let mut manager = VSOCK_CONN_MANAGER.lock();
-                            let _ = manager.on_data_received(conn_id, &buf[..read_len]);
-                            trace!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len);
-                        }
-                    }else{
-                        trace!("Vsock received event but no free space: conn_id={:?}, free_space={}", conn_id, free_space);
-                    }
-                } else {
-                    event_count += 1;
-                    handle_vsock_event(event);
-                }
-
+                event_count += 1;
+                handle_vsock_event(event, dev);
             }
             Err(e) => {
                 info!("Failed to poll vsock event: {:?}", e);
@@ -173,7 +157,7 @@ fn poll_vsock_interfaces() -> AxResult<bool> {
     Ok(event_count > 0)
 }
 
-fn handle_vsock_event(event: VsockDriverEvent) {
+fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
     let mut manager = VSOCK_CONN_MANAGER.lock();
     debug!("Handling vsock event: {:?}", event);
 
@@ -182,8 +166,25 @@ fn handle_vsock_event(event: VsockDriverEvent) {
             let _ = manager.on_connection_request(conn_id);
         }
 
-        VsockDriverEvent::Received(_conn_id, _len) => {
-            // Handled in poll_vsock_interfaces directly to support backpressure
+        VsockDriverEvent::Received(conn_id, len) => {
+            let mut buf = alloc::vec![0; 0x1000]; // 4KiB buffer for receiving data
+            let free_space = if let Some(conn) = manager.get_connection(conn_id) {
+                conn.lock().rx_buffer_free()
+            } else {
+                buf.len()
+            };
+
+            if free_space > 0 {
+                // Read as much as the upper layer can accept, up to buf.len()
+                let max_read = core::cmp::min(free_space, buf.len());
+                if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
+                    let _ = manager.on_data_received(conn_id, &buf[..read_len]);
+                    debug!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len);
+                }
+            } else {
+                debug!("Vsock received event but no free space: conn_id={:?}, free_space={}", conn_id, free_space);
+                PENDING_EVENTS.lock().push_back(VsockDriverEvent::Received(conn_id, len));
+            }
         }
 
         VsockDriverEvent::Disconnected(conn_id) => {

--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -15,6 +15,8 @@ use alloc::collections::VecDeque;
 static VSOCK_DEVICE: Mutex<Option<AxVsockDevice>> = Mutex::new(None);
 static PENDING_EVENTS: Mutex<VecDeque<VsockDriverEvent>> = Mutex::new(VecDeque::new());
 
+const VSOCK_RX_TMPBUF_SIZE: usize = 0x1000; // 4KiB buffer for vsock receive
+
 /// Registers a vsock device. Only one vsock device can be registered.
 pub fn register_vsock_device(dev: AxVsockDevice) -> AxResult {
     let mut guard = VSOCK_DEVICE.lock();
@@ -167,15 +169,15 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
         }
 
         VsockDriverEvent::Received(conn_id, len) => {
-            let mut buf = alloc::vec![0; 0x1000]; // 4KiB buffer for receiving data
             let free_space = if let Some(conn) = manager.get_connection(conn_id) {
                 conn.lock().rx_buffer_free()
             } else {
-                buf.len()
+                return;
             };
 
             if free_space > 0 {
-                // Read as much as the upper layer can accept, up to buf.len()
+                // Read as much as the upper layer can accept, up to VSOCK_RX_TMPBUF_SIZE
+                let mut buf = alloc::vec![0; VSOCK_RX_TMPBUF_SIZE];
                 let max_read = core::cmp::min(free_space, buf.len());
                 if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
                     let _ = manager.on_data_received(conn_id, &buf[..read_len]);

--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -165,36 +165,55 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
 
     match event {
         VsockDriverEvent::ConnectionRequest(conn_id) => {
-            let _ = manager.on_connection_request(conn_id);
+            match manager.on_connection_request(conn_id) {
+                Ok(_) => debug!("Connection request accepted: {:?}", conn_id),
+                Err(e) => warn!("Connection request failed: {:?}, error={:?}", conn_id, e),
+            }
         }
 
         VsockDriverEvent::Received(conn_id, len) => {
             let free_space = if let Some(conn) = manager.get_connection(conn_id) {
                 conn.lock().rx_buffer_free()
             } else {
+                warn!("Received data for unknown connection: {:?}", conn_id);
                 return;
             };
 
-            if free_space > 0 {
-                // Read as much as the upper layer can accept, up to VSOCK_RX_TMPBUF_SIZE
-                let mut buf = alloc::vec![0; VSOCK_RX_TMPBUF_SIZE];
-                let max_read = core::cmp::min(free_space, buf.len());
-                if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
-                    let _ = manager.on_data_received(conn_id, &buf[..read_len]);
-                    debug!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len);
-                }
-            } else {
-                debug!("Vsock received event but no free space: conn_id={:?}, free_space={}", conn_id, free_space);
+            if free_space == 0 {
+                debug!("No free space in rx buffer for conn_id={:?}, deferring receive", conn_id);
                 PENDING_EVENTS.lock().push_back(VsockDriverEvent::Received(conn_id, len));
+                return;
+            }
+
+            let mut buf = alloc::vec![0; VSOCK_RX_TMPBUF_SIZE];
+            let max_read = core::cmp::min(free_space, buf.len());
+            match dev.recv(conn_id, &mut buf[..max_read]) {
+                Ok(read_len) => {
+                    match manager.on_data_received(conn_id, &buf[..read_len]) {
+                        Ok(_) => debug!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len),
+                        Err(e) => {
+                            warn!("Failed to handle received data: conn_id={:?}, error={:?}", conn_id, e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to receive vsock data: conn_id={:?}, error={:?}", conn_id, e);
+                }
             }
         }
 
         VsockDriverEvent::Disconnected(conn_id) => {
-            let _ = manager.on_disconnected(conn_id);
+            match manager.on_disconnected(conn_id) {
+                Ok(_) => debug!("Connection disconnected: {:?}", conn_id),
+                Err(e) => warn!("Failed to handle disconnection: {:?}, error={:?}", conn_id, e),
+            }
         }
 
         VsockDriverEvent::Connected(conn_id) => {
-            let _ = manager.on_connected(conn_id);
+            match manager.on_connected(conn_id) {
+                Ok(_) => debug!("Connection established: {:?}", conn_id),
+                Err(e) => warn!("Failed to handle connection established: {:?}, error={:?}", conn_id, e),
+            }
         }
 
         VsockDriverEvent::Unknown => warn!("Received unknown vsock event"),


### PR DESCRIPTION
之前问题根因：
virtiodriver底层驱动默认设置ringbuffer为1K。发送端发送1K后，starryos没有收到发送端的RecditRequest，因此需要主动的update

修改办法：
1. recv后主动update的代码修改在axdriver_crates中的[PR](https://github.com/kylin-x-kernel/axdriver_crates/pull/2)中
2. 轮训到Received事件后，是否recv不再交由axdriver决定，而是交由更上层决定，（当上层buffer有容量则尽可能读取数据，没容量则不读以防drop）
3. 移除了非必要参数

测试：
验证了修改后的 `poll_vsock_interfaces` 函数能够正确处理以下情况：

1.  正常接收：上层有足够空间，数据被正确读取。
2.  底层ringbuffer压测：底层层空间不足，上层充足，能够尽所能转移底层数据
3.  上层ringbuffer压测：上层空间不足，只读取部分数据，剩余数据留在底层驱动中，不丢包，记录忽视的received事件。
4. 完全饱满：上层空间不足时，若上层和底层ringbuffer完全没空间，完全不读取数据，不丢包，不发送。当上层有空间则根据已记录但忽视的事件主动recv