### PR TITLE
Fixvsock about sending

### DIFF
--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -165,9 +165,8 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
 
     match event {
         VsockDriverEvent::ConnectionRequest(conn_id) => {
-            match manager.on_connection_request(conn_id) {
-                Ok(_) => debug!("Connection request accepted: {:?}", conn_id),
-                Err(e) => warn!("Connection request failed: {:?}, error={:?}", conn_id, e),
+            if let Err(e) = manager.on_connection_request(conn_id) {
+                warn!("Connection request failed: {:?}, error={:?}", conn_id, e);
             }
         }
 
@@ -180,7 +179,6 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
             };
 
             if free_space == 0 {
-                debug!("No free space in rx buffer for conn_id={:?}, deferring receive", conn_id);
                 PENDING_EVENTS.lock().push_back(VsockDriverEvent::Received(conn_id, len));
                 return;
             }
@@ -189,11 +187,8 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
             let max_read = core::cmp::min(free_space, buf.len());
             match dev.recv(conn_id, &mut buf[..max_read]) {
                 Ok(read_len) => {
-                    match manager.on_data_received(conn_id, &buf[..read_len]) {
-                        Ok(_) => debug!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len),
-                        Err(e) => {
-                            warn!("Failed to handle received data: conn_id={:?}, error={:?}", conn_id, e);
-                        }
+                    if let Err(e) = manager.on_data_received(conn_id, &buf[..read_len]) {
+                       warn!("Failed to handle received data: conn_id={:?}, error={:?}", conn_id, e);
                     }
                 }
                 Err(e) => {
@@ -203,16 +198,14 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
         }
 
         VsockDriverEvent::Disconnected(conn_id) => {
-            match manager.on_disconnected(conn_id) {
-                Ok(_) => debug!("Connection disconnected: {:?}", conn_id),
-                Err(e) => warn!("Failed to handle disconnection: {:?}, error={:?}", conn_id, e),
+            if let Err(e) = manager.on_disconnected(conn_id) {
+                warn!("Failed to handle disconnection: {:?}, error={:?}", conn_id, e);
             }
         }
 
         VsockDriverEvent::Connected(conn_id) => {
-            match manager.on_connected(conn_id) {
-                Ok(_) => debug!("Connection established: {:?}", conn_id),
-                Err(e) => warn!("Failed to handle connection established: {:?}, error={:?}", conn_id, e),
+            if let Err(e) = manager.on_connected(conn_id) {
+                warn!("Failed to handle connection established: {:?}, error={:?}", conn_id, e);
             }
         }
 

--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -134,11 +134,35 @@ fn poll_vsock_interfaces() -> AxResult<bool> {
     let mut buf = alloc::vec![0; 0x1000]; // 4KiB buffer for receiving data
 
     loop {
-        match dev.poll_event(&mut buf) {
+        match dev.poll_event() {
             Ok(None) => break, // no more events
             Ok(Some(event)) => {
-                event_count += 1;
-                handle_vsock_event(event, &buf);
+
+                if let VsockDriverEvent::Received(conn_id, _len) = event {
+                    let mut manager = VSOCK_CONN_MANAGER.lock();
+                    let free_space = if let Some(conn) = manager.get_connection(conn_id) {
+                        conn.lock().rx_buffer_free()
+                    } else {
+                        buf.len()
+                    };
+                    drop(manager);
+
+                    if free_space > 0 {
+                        // Read as much as the upper layer can accept, up to buf.len()
+                        let max_read = core::cmp::min(free_space, buf.len());
+                        if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
+                            let mut manager = VSOCK_CONN_MANAGER.lock();
+                            let _ = manager.on_data_received(conn_id, &buf[..read_len]);
+                            trace!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len);
+                        }
+                    }else{
+                        trace!("Vsock received event but no free space: conn_id={:?}, free_space={}", conn_id, free_space);
+                    }
+                } else {
+                    event_count += 1;
+                    handle_vsock_event(event);
+                }
+
             }
             Err(e) => {
                 info!("Failed to poll vsock event: {:?}", e);
@@ -149,7 +173,7 @@ fn poll_vsock_interfaces() -> AxResult<bool> {
     Ok(event_count > 0)
 }
 
-fn handle_vsock_event(event: VsockDriverEvent, buf: &[u8]) {
+fn handle_vsock_event(event: VsockDriverEvent) {
     let mut manager = VSOCK_CONN_MANAGER.lock();
     debug!("Handling vsock event: {:?}", event);
 
@@ -158,8 +182,8 @@ fn handle_vsock_event(event: VsockDriverEvent, buf: &[u8]) {
             let _ = manager.on_connection_request(conn_id);
         }
 
-        VsockDriverEvent::Received(conn_id, len) => {
-            let _ = manager.on_data_received(conn_id, &buf[..len]);
+        VsockDriverEvent::Received(_conn_id, _len) => {
+            // Handled in poll_vsock_interfaces directly to support backpressure
         }
 
         VsockDriverEvent::Disconnected(conn_id) => {

--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -9,9 +9,11 @@ use axsync::Mutex;
 use axtask::future::{block_on, interruptible};
 
 use crate::{alloc::string::ToString, vsock::connection_manager::VSOCK_CONN_MANAGER};
+use alloc::collections::VecDeque;
 
 // we need a global and static only one vsock device
 static VSOCK_DEVICE: Mutex<Option<AxVsockDevice>> = Mutex::new(None);
+static PENDING_EVENTS: Mutex<VecDeque<VsockDriverEvent>> = Mutex::new(VecDeque::new());
 
 /// Registers a vsock device. Only one vsock device can be registered.
 pub fn register_vsock_device(dev: AxVsockDevice) -> AxResult {
@@ -131,38 +133,20 @@ fn poll_vsock_interfaces() -> AxResult<bool> {
     let mut guard = VSOCK_DEVICE.lock();
     let dev = guard.as_mut().ok_or(AxError::NotFound)?;
     let mut event_count = 0;
-    let mut buf = alloc::vec![0; 0x1000]; // 4KiB buffer for receiving data
+
+    // Process pending events first
+    // Use core::mem::take to atomically move all events out and empty the global queue
+    let pending_events = core::mem::take(&mut *PENDING_EVENTS.lock());
+    for event in pending_events {
+        handle_vsock_event(event, dev);
+    }
 
     loop {
         match dev.poll_event() {
             Ok(None) => break, // no more events
             Ok(Some(event)) => {
-
-                if let VsockDriverEvent::Received(conn_id, _len) = event {
-                    let mut manager = VSOCK_CONN_MANAGER.lock();
-                    let free_space = if let Some(conn) = manager.get_connection(conn_id) {
-                        conn.lock().rx_buffer_free()
-                    } else {
-                        buf.len()
-                    };
-                    drop(manager);
-
-                    if free_space > 0 {
-                        // Read as much as the upper layer can accept, up to buf.len()
-                        let max_read = core::cmp::min(free_space, buf.len());
-                        if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
-                            let mut manager = VSOCK_CONN_MANAGER.lock();
-                            let _ = manager.on_data_received(conn_id, &buf[..read_len]);
-                            trace!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len);
-                        }
-                    }else{
-                        trace!("Vsock received event but no free space: conn_id={:?}, free_space={}", conn_id, free_space);
-                    }
-                } else {
-                    event_count += 1;
-                    handle_vsock_event(event);
-                }
-
+                event_count += 1;
+                handle_vsock_event(event, dev);
             }
             Err(e) => {
                 info!("Failed to poll vsock event: {:?}", e);
@@ -173,7 +157,7 @@ fn poll_vsock_interfaces() -> AxResult<bool> {
     Ok(event_count > 0)
 }
 
-fn handle_vsock_event(event: VsockDriverEvent) {
+fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
     let mut manager = VSOCK_CONN_MANAGER.lock();
     debug!("Handling vsock event: {:?}", event);
 
@@ -182,8 +166,25 @@ fn handle_vsock_event(event: VsockDriverEvent) {
             let _ = manager.on_connection_request(conn_id);
         }
 
-        VsockDriverEvent::Received(_conn_id, _len) => {
-            // Handled in poll_vsock_interfaces directly to support backpressure
+        VsockDriverEvent::Received(conn_id, len) => {
+            let mut buf = alloc::vec![0; 0x1000]; // 4KiB buffer for receiving data
+            let free_space = if let Some(conn) = manager.get_connection(conn_id) {
+                conn.lock().rx_buffer_free()
+            } else {
+                buf.len()
+            };
+
+            if free_space > 0 {
+                // Read as much as the upper layer can accept, up to buf.len()
+                let max_read = core::cmp::min(free_space, buf.len());
+                if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
+                    let _ = manager.on_data_received(conn_id, &buf[..read_len]);
+                    debug!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len);
+                }
+            } else {
+                debug!("Vsock received event but no free space: conn_id={:?}, free_space={}", conn_id, free_space);
+                PENDING_EVENTS.lock().push_back(VsockDriverEvent::Received(conn_id, len));
+            }
         }
 
         VsockDriverEvent::Disconnected(conn_id) => {

--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -15,6 +15,8 @@ use alloc::collections::VecDeque;
 static VSOCK_DEVICE: Mutex<Option<AxVsockDevice>> = Mutex::new(None);
 static PENDING_EVENTS: Mutex<VecDeque<VsockDriverEvent>> = Mutex::new(VecDeque::new());
 
+const VSOCK_RX_TMPBUF_SIZE: usize = 0x1000; // 4KiB buffer for vsock receive
+
 /// Registers a vsock device. Only one vsock device can be registered.
 pub fn register_vsock_device(dev: AxVsockDevice) -> AxResult {
     let mut guard = VSOCK_DEVICE.lock();
@@ -167,15 +169,15 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
         }
 
         VsockDriverEvent::Received(conn_id, len) => {
-            let mut buf = alloc::vec![0; 0x1000]; // 4KiB buffer for receiving data
             let free_space = if let Some(conn) = manager.get_connection(conn_id) {
                 conn.lock().rx_buffer_free()
             } else {
-                buf.len()
+                return;
             };
 
             if free_space > 0 {
-                // Read as much as the upper layer can accept, up to buf.len()
+                // Read as much as the upper layer can accept, up to VSOCK_RX_TMPBUF_SIZE
+                let mut buf = alloc::vec![0; VSOCK_RX_TMPBUF_SIZE];
                 let max_read = core::cmp::min(free_space, buf.len());
                 if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
                     let _ = manager.on_data_received(conn_id, &buf[..read_len]);

--- a/modules/axnet/src/device/vsock.rs
+++ b/modules/axnet/src/device/vsock.rs
@@ -165,36 +165,55 @@ fn handle_vsock_event(event: VsockDriverEvent, dev: &mut dyn VsockDriverOps) {
 
     match event {
         VsockDriverEvent::ConnectionRequest(conn_id) => {
-            let _ = manager.on_connection_request(conn_id);
+            match manager.on_connection_request(conn_id) {
+                Ok(_) => debug!("Connection request accepted: {:?}", conn_id),
+                Err(e) => warn!("Connection request failed: {:?}, error={:?}", conn_id, e),
+            }
         }
 
         VsockDriverEvent::Received(conn_id, len) => {
             let free_space = if let Some(conn) = manager.get_connection(conn_id) {
                 conn.lock().rx_buffer_free()
             } else {
+                warn!("Received data for unknown connection: {:?}", conn_id);
                 return;
             };
 
-            if free_space > 0 {
-                // Read as much as the upper layer can accept, up to VSOCK_RX_TMPBUF_SIZE
-                let mut buf = alloc::vec![0; VSOCK_RX_TMPBUF_SIZE];
-                let max_read = core::cmp::min(free_space, buf.len());
-                if let Ok(read_len) = dev.recv(conn_id, &mut buf[..max_read]) {
-                    let _ = manager.on_data_received(conn_id, &buf[..read_len]);
-                    debug!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len);
-                }
-            } else {
-                debug!("Vsock received event but no free space: conn_id={:?}, free_space={}", conn_id, free_space);
+            if free_space == 0 {
+                debug!("No free space in rx buffer for conn_id={:?}, deferring receive", conn_id);
                 PENDING_EVENTS.lock().push_back(VsockDriverEvent::Received(conn_id, len));
+                return;
+            }
+
+            let mut buf = alloc::vec![0; VSOCK_RX_TMPBUF_SIZE];
+            let max_read = core::cmp::min(free_space, buf.len());
+            match dev.recv(conn_id, &mut buf[..max_read]) {
+                Ok(read_len) => {
+                    match manager.on_data_received(conn_id, &buf[..read_len]) {
+                        Ok(_) => debug!("Vsock data received: conn_id={:?}, free_space={}, max_read={}, read_len={}", conn_id, free_space, max_read, read_len),
+                        Err(e) => {
+                            warn!("Failed to handle received data: conn_id={:?}, error={:?}", conn_id, e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to receive vsock data: conn_id={:?}, error={:?}", conn_id, e);
+                }
             }
         }
 
         VsockDriverEvent::Disconnected(conn_id) => {
-            let _ = manager.on_disconnected(conn_id);
+            match manager.on_disconnected(conn_id) {
+                Ok(_) => debug!("Connection disconnected: {:?}", conn_id),
+                Err(e) => warn!("Failed to handle disconnection: {:?}, error={:?}", conn_id, e),
+            }
         }
 
         VsockDriverEvent::Connected(conn_id) => {
-            let _ = manager.on_connected(conn_id);
+            match manager.on_connected(conn_id) {
+                Ok(_) => debug!("Connection established: {:?}", conn_id),
+                Err(e) => warn!("Failed to handle connection established: {:?}, error={:?}", conn_id, e),
+            }
         }
 
         VsockDriverEvent::Unknown => warn!("Received unknown vsock event"),

--- a/modules/axnet/src/vsock/connection_manager.rs
+++ b/modules/axnet/src/vsock/connection_manager.rs
@@ -3,6 +3,7 @@ use alloc::{collections::BTreeMap, sync::Arc};
 use axerrno::{AxError, AxResult, ax_bail};
 use axpoll::PollSet;
 use axsync::Mutex;
+use axtask::WaitQueue;
 use ringbuf::{HeapCons, HeapProd, HeapRb, traits::*};
 
 use super::{VsockAddr, VsockConnId};
@@ -30,6 +31,9 @@ pub struct Connection {
     rx_producer: HeapProd<u8>,
     rx_consumer: HeapCons<u8>,
 
+    /// wait queues for tx due to InsufficientBufferSpaceInPeer
+    tx_wait_queue: WaitQueue,
+
     /// Waker lists
     rx_wakers: PollSet,
     connect_wakers: PollSet,
@@ -54,6 +58,7 @@ impl Connection {
             peer_addr,
             rx_producer,
             rx_consumer,
+            tx_wait_queue: WaitQueue::default(),
             rx_wakers: PollSet::new(),
             connect_wakers: PollSet::new(),
             rx_closed: false,
@@ -125,6 +130,16 @@ impl Connection {
             );
             0
         }
+    }
+
+    #[inline]
+    pub fn wait_for_tx(&self){
+        self.tx_wait_queue.wait_timeout(core::time::Duration::from_millis(10));
+    }
+
+    #[inline]
+    pub fn tx_wait_queue_notify(&mut self) {
+        self.tx_wait_queue.notify_all(true);
     }
 
     #[inline]
@@ -470,6 +485,19 @@ impl VsockConnectionManager {
             conn_guard.state = ConnectionState::Connected;
             conn_guard.wake_connect();
             trace!("Connection {:?} established", conn_id);
+        }
+        Ok(())
+    }
+
+    /// handle credit update (by driver event)
+    /// The code for credit_update has been completed in the virtio_driver layer. 
+    /// The purpose of credit_update here is to correspond to events and 
+    /// notify which tasks failed to be sent due to credit not being updated
+    pub fn on_credit_update(&mut self, conn_id: VsockConnId) -> AxResult<()> {
+        if let Some(conn) = self.connections.get(&conn_id) {
+            let mut conn_guard = conn.lock();
+            conn_guard.tx_wait_queue_notify();
+            trace!("Connection {:?} tx wait queue notified", conn_id);
         }
         Ok(())
     }


### PR DESCRIPTION
背景
经测试，host与starry建立vsock连接，host告诉starry最大alloc_buf是256KB，starry持续发送数据给host。看virtio-driver源码，send前先进行check_peer_buffer_is_sufficient条件判断，如果条件判断不满足则发起CreditRequest事件请求并返回Err(SocketError::InsufficientBufferSpaceInPeer.into())。

问题：
1. 持续发送数据超过256KB，由于返回特殊Err（SocketError::InsufficientBufferSpaceInPeer ----> DevError::Again）但没有错误处理，导致发送中途panic

解决：
1. 当send失败且有DevError::Again错误，send进入waitqueue等待notify
2. 添加axnet中添加对creditupdate事件的处理，唤醒waitqueue中的任务

相关pr：
[axdriver_crate](https://github.com/kylin-x-kernel/axdriver_crates/pull/3)

